### PR TITLE
Extended env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,20 @@
-# $NAME is used
+# $NAME is used by both deployment methods (standalone docker exposing its port + traefik routing)
 # - as container name, and therefore should be unic accross all your blogs
-# - as path prefix when routing with traefik
 # - as folder name to locally store your data blog (thanks to docker volumes)
 NAME?=ghost-local
 
-# $DOMAIN is used by both deployment methods (standalone docker exposing its port + traefik routing)
+# $PROTOCOL is only used by traefik
+# - default is http
+# - when using https, traefik will get a certificate from Let's Encrypt. 
+#   -> Make sure that your $DOMAIN is accessible
+PROTOCOL?=http
+
+# $DOMAIN is used by both deployment methods
 DOMAIN?=localhost
 
-# $PORT is only used to map docker port (2368) on the host, when running a standalone container
+# $PORT is only used by standalone containers
 PORT?=3001
+
+# $URI is only used by traefik
+# - as path prefix when routing with traefik
+URI?=${NAME}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ ToC
 
 - [Installation and usage](#installation-and-usage)
 - [Helpers for developers](#helpers-for-developers)
-    - [make ps-light](#make-ps-light)
+    - [make vars](#make-vars)
+    - [make ps](#make-ps)
     - [[NAME=ghost-local] make shell](#nameghost-local-make-shell)
     - [[NAME=ghost-local] make logs](#nameghost-local-make-logs)
     - [[NAME=ghost-local] make stop](#nameghost-local-make-stop)
@@ -69,11 +70,35 @@ Now that you have one (or more) blogs running, you might want to check their sta
 
 A few helpers command are provided within the Makefile:
 
-### make ps-light
+### make vars
+
+It will list the values currently set of your environment variables
+
+    $ make vars
+    # values that will be used to create the blog URL
+      NAME=ghost-local
+      PROTOCOL=http
+      DOMAIN=localhost
+      PORT=3001
+      URI=ghost-local
+
+As with all other commands, you can override them either in [.env](./.env) file or through the command line:
+
+    $ NAME=foo URI=bar PORT=3002 make vars
+    # values that will be used to create the blog URL
+      NAME=foo
+      PROTOCOL=http
+      DOMAIN=localhost
+      PORT=3002
+      URI=bar
+
+More information on those variables can be found in [INSTALL.md](./docs/INSTALL.md#default-configuration)
+
+### make ps
 
 It will act as `docker ps`, displaying less columns
 
-    $ make ps-light
+    $ make ps
     # A lightly formatted version of docker ps
     docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}} ago'
     NAMES               IMAGE                           STATUS ago
@@ -119,7 +144,8 @@ This will stop and delete the container with given NAME. Data is not lost though
 
 ### Look for what's coming next...
 
-1. Document HTTPs
+1. (/) Document HTTPs
+1. (/) Authorize blog on raw domain (without named folder)
 1. Make use of MariaDB and Nginx
 1. Consolidate for production
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,8 +11,10 @@ ToC
     - [per-port basis](#per-port-basis)
     - [per-path basis](#per-path-basis)
 - [Setup](#setup)
+    - [Default configuration](#default-configuration)
     - [per-port basis](#per-port-basis-1)
     - [per-path basis](#per-path-basis-1)
+    - [HTTPs ?](#https-)
 
 <!-- /TOC -->
 
@@ -33,7 +35,21 @@ Feel free to use my companion repo, [prod-stack](https://github.com/ebreton/prod
 
 ## Setup
 
+### Default configuration
+
+Variables are defined in [.env](../.env) file, and can be modified in the command line when calling `make`. The file is self-documented, but here is a summary of the variables and default values:
+
+Name | description | default | used by standalone container / traefik
+---------|----------|----------|---------
+ NAME | for the container and the data folder | ghost-local | both
+ PROTOCOL | to build the URL | http | traefik
+ DOMAIN | to build the URL | localhost | both
+ PORT | to build the URL | 3001 | standalone
+ URI | to build the URL | ${NAME} | traefik
+
 ### per-port basis
+
+> The following variables will be used: NAME, DOMAIN, PORT, URI
 
 To get everything running, what could be better than one line?
 
@@ -51,10 +67,10 @@ To get everything running, what could be better than one line?
 You will be able to check that everything went ok 
 
 1. on <http://localhost:3001>,
-2. through the logs, or
-3. by running `make ps-light`
+2. through the logs (`make logs`)
+3. by running `make ps`
 
-        $ make ps-light
+        $ make ps
         # A lightly formatted version of docker ps
         docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}} ago'
         NAMES               IMAGE                           STATUS ago
@@ -65,6 +81,8 @@ You will be able to check that everything went ok
     NAME=another PORT=3002 make
 
 ### per-path basis
+
+> The following variables will be used: NAME, PROTOCOL, DOMAIN, URI
 
 The [prod-stack](https://github.com/ebreton/prod-stack) will actually offer you more than a proxy-combo: you will get what you could need in production (Nginx, MariaDB, and use of Let's Encrypt for HTTPs)
 
@@ -89,3 +107,14 @@ If you have already launched a container with the default environment variables,
 * `NAME=hello make traefik` to get a fresh blog running on <http://localhost/hello>
 * `NAME=bye make traefik` to get another blog running on <http://localhost/bye>
 * and so on...
+
+### HTTPs ?
+
+The default configuration will set-up everything on HTTP. But the [prod-stack](https://github.com/ebreton/prod-stack) can to serve HTTPs (as well as support Let's Encrypt protocol, and force redirection from HTTP to HTTPs)
+
+You only have to:
+
+1. change the env var $PROTOCOL to https
+1. make sure though that your $DOMAIN is accessible externaly
+
+The second point is a MUST since traefik will get the certificate from Let's Encrypt, that will need access to your domain in return.


### PR DESCRIPTION
**Targetted version**: 0.1.2

**High level changes:**

1. split env vars for container, data folder ($NAME) from the one for the URL path ($URI)
1. added documentation for env vars in .env, README and INSTALL
1. expose and document HTTPs (with env var $PROTOCOL)
