### PR TITLE
Added make restart/upgrade and subfolder instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
-ghost-local
+themes
+instances

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION:=$(shell python update_release.py -v)
 dev: check-env
 	# Simply start a ghost container making it directly available through $$PORT
 	docker run --rm -d --name ${NAME} \
-		-v $(shell pwd)/${NAME}:/var/lib/ghost/content \
+		-v $(shell pwd)/instances/${NAME}:/var/lib/ghost/content \
 		-p ${PORT}:2368 \
 		-e url=http://${DOMAIN}:${PORT} \
 		ghost:1-alpine
@@ -20,7 +20,7 @@ traefik: check-env
 	# Start a ghost container behind traefik (therefore available through 80 or 443), on path $$NAME
 	# Beware of --network used, which is the same one traefik should be using
 	docker run --rm -d --name ${NAME} \
-		-v $(shell pwd)/${NAME}:/var/lib/ghost/content \
+		-v $(shell pwd)/instances/${NAME}:/var/lib/ghost/content \
 		-e url=${PROTOCOL}://${DOMAIN}/${URI} \
 		--network=proxy \
 		--label "traefik.enable=true" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # or in .env
 
 .PHONY: dev traefik vars \
-	cli-version ps shell logs stop \
+	cli-version ps shell logs stop pull \
 	app-version release push-qa push-prod update-changelog 
 
 VERSION:=$(shell python update_release.py -v)
@@ -65,6 +65,9 @@ logs:
 
 stop:
 	docker stop ${NAME}
+
+pull:
+	docker pull ghost:1-alpine
 
 
 # RELEASE PROCESS related commands

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ stop:
 pull:
 	docker pull ghost:1-alpine
 
+restart: stop traefik logs
+
+upgrade: pull restart
+
 
 # RELEASE PROCESS related commands
 ###

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Command | Description | Variables
  `make shell` | Connect to given Ghost container | NAME
  `make logs` | Tail and follow the logs of given Ghost container | NAME
  `make stop` | Stop given Ghost container | NAME
+ `make pull` | Update docker image from dockerhub | None
 
 More detailed can be found in [HELPERS.md](./docs/HELPERS.md)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You want to play a bit more, and you would like to have multiple Ghosts on your 
 * or leverage the power of [traefik](https://traefik.io) and have multiple ghosts on a **per-path basis** (see section below)
     > e.g.: `NAME=yet-another make traefik`. Head to <http://localhost/yet-another>
 
-If you are worried with your data, be at rest: a local folder is created for every blog you create, named from $NAME variable. Stopping and restarting a blog with the same name will keep using the local data
+If you are worried with your data, be at rest: a local folder is created within path _./instances_, for every blog you create, named from $NAME variable. Stopping and restarting a blog with the same name will keep using the local data.
 
 ## Installation and usage
 
@@ -76,6 +76,8 @@ Command | Description | Variables
  `make logs` | Tail and follow the logs of given Ghost container | NAME
  `make stop` | Stop given Ghost container | NAME
  `make pull` | Update docker image from dockerhub | None
+ `make restart` | Calls `make stop traefik logs` | NAME
+ `make upgrade` | Calls `make pull restart` | NAME
 
 More detailed can be found in [HELPERS.md](./docs/HELPERS.md)
 

--- a/docs/HELPERS.md
+++ b/docs/HELPERS.md
@@ -12,6 +12,7 @@ ToC
 - [[NAME=ghost-local] make logs](#nameghost-local-make-logs)
 - [[NAME=ghost-local] make stop](#nameghost-local-make-stop)
 - [make pull](#make-pull)
+- [make restart and make upgrades](#make-restart-and-make-upgrades)
 
 <!-- /TOC -->
 
@@ -95,3 +96,11 @@ Fetches the latest docker image (if necessary) from docker hub
     1-alpine: Pulling from library/ghost
     Digest: sha256:46b8d0e2437c46af0c2579a4a717a20c4253da2b75bb4dd4875b7686aaa9ca8d
     Status: Image is up to date for ghost:1-alpine
+
+## make restart and make upgrades
+
+Those two commands are simple aliases defined for conveniency:
+
+    restart: stop traefik logs
+
+    upgrade: pull restart

--- a/docs/HELPERS.md
+++ b/docs/HELPERS.md
@@ -11,6 +11,7 @@ ToC
 - [[NAME=ghost-local] make shell](#nameghost-local-make-shell)
 - [[NAME=ghost-local] make logs](#nameghost-local-make-logs)
 - [[NAME=ghost-local] make stop](#nameghost-local-make-stop)
+- [make pull](#make-pull)
 
 <!-- /TOC -->
 
@@ -84,3 +85,13 @@ This will stop and delete the container with given NAME. Data is not lost though
     docker stop ghost-local
     ghost-local
     (ghost-in-a-shell-JYrXbwAb)
+
+## make pull
+
+Fetches the latest docker image (if necessary) from docker hub
+
+    $ make pull
+    docker pull ghost:1-alpine
+    1-alpine: Pulling from library/ghost
+    Digest: sha256:46b8d0e2437c46af0c2579a4a717a20c4253da2b75bb4dd4875b7686aaa9ca8d
+    Status: Image is up to date for ghost:1-alpine

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -41,7 +41,7 @@ Variables are defined in [.env](../.env) file, and can be modified in the comman
 
 Name | description | default | used by standalone container / traefik
 ---------|----------|----------|---------
- NAME | for the container and the data folder | ghost-local | both
+ NAME | for the container and the data folder (stored within _./instances_) | ghost-local | both
  PROTOCOL | to build the URL | http | traefik
  DOMAIN | to build the URL | localhost | both
  PORT | to build the URL | 3001 | standalone

--- a/versions.py
+++ b/versions.py
@@ -3,14 +3,14 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.1.2-2-gcec557c'
+_release = '0.1.2-10-g2c29ff5'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
 # => read-write, >_release
-_version = '0.1.3-rc'
+_version = '0.2.0'
 
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = 'cec557c4e1af42e94f61d3a276c82c4caaa15352'
+_build = '2c29ff5fcfa93b6efdb374ae71e6db04c9c7096e'

--- a/versions.py
+++ b/versions.py
@@ -3,14 +3,14 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.1.1-16-g5c88f7a'
+_release = '0.1.2-2-gcec557c'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
 # => read-write, >_release
-_version = '0.1.2'
+_version = '0.1.3-rc'
 
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = '5c88f7aca8412b75a210184db1da0ec707a67a1c'
+_build = 'cec557c4e1af42e94f61d3a276c82c4caaa15352'


### PR DESCRIPTION
**Targetted version**: 0.2.0

⚠️  **Backward incompatible changes:** data volumes are now created within subfolder **./instances**. You will need to move your data in this new place 

**High level changes:**

1. `make restart` stops instances defined by current variables, and start it again with traefik. Logs are tailed and followed to check the proper restart of the container
1. `make upgrade` pulls the ghost image from docker hub, and then restart the container
1. all data volumes are created in sub-folder **./instances**, instead of root folder of the repo

**Low level changes:**

1. all data folder are not git-ignored whereas only ghost-local (default configuration) was ignored before