### PR TITLE
added env variables for DB and Emails

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
-# $NAME is used by both deployment methods (standalone docker exposing its port + traefik routing)
+# $NAME is used by all deployment methods
 # - as container name, and therefore should be unic accross all your blogs
 # - as folder name to locally store your data blog (thanks to docker volumes)
 NAME?=ghost-local
 
-# $PROTOCOL is only used by traefik
+# $PROTOCOL is only used by traefik (QA and Prod deployments)
 # - default is http
 # - when using https, traefik will get a certificate from Let's Encrypt. 
 #   -> Make sure that your $DOMAIN is accessible
@@ -12,9 +12,9 @@ PROTOCOL?=http
 # $DOMAIN is used by both deployment methods
 DOMAIN?=localhost
 
-# $PORT is only used by standalone containers
+# $PORT is only used by dev deployments
 PORT?=3001
 
-# $URI is only used by traefik
+# $URI is only used by traefik (QA and Prod deployments)
 # - as path prefix when routing with traefik
 URI?=${NAME}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-*.pyc
+prod.env
+
 themes
 instances
 tmp
+
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ qa: check-env
 		--label "traefik.frontend.rule=Host:${DOMAIN};PathPrefix:/${URI}" \
 		ghost:1-alpine
 
+# for backward compatibility
+traefik: qa
+	@echo ""
+	@echo "!! DEPRECATION WARNING: 'make traefik' is replaced by 'make qa'. This command will be dropped in version 0.4"
+
 prod: check-prod-env
 	# Same configuration as make `traefik`, specifying DB
 	docker run --rm -d --user node --name ${NAME} \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You want to play a bit more, and you would like to have multiple Ghosts on your 
 * Either use *make* again and again with different variables, to get your blogs on a **per-port basis**
     > e.g.: `NAME=another PORT=3002 make` for a second blog on <http://localhost:3002>
 * or leverage the power of [traefik](https://traefik.io) and have multiple ghosts on a **per-path basis** (see section below)
-    > e.g.: `NAME=yet-another make traefik`. Head to <http://localhost/yet-another>
+    > e.g.: `NAME=yet-another make qa`. Head to <http://localhost/yet-another>
 
 If you are worried with your data, be at rest: a local folder is created within path _./instances_, for every blog you create, named from $NAME variable. Stopping and restarting a blog with the same name will keep using the local data.
 
@@ -59,7 +59,7 @@ If you are worried with your data, be at rest: a local folder is created within 
 
 Installation is straightforward if you simply wish to bridge to a container port (3001 by default). `make` will do.
 
-However, it is not really convenient if you wish to serve on standard ports (80 or 443) and if you want anyone to access your blog easily. In this case, you will need to setup traefik router, and run `make traefik`
+However, it is not really convenient if you wish to serve on standard ports (80 or 443) and if you want anyone to access your blog easily. In this case, you will need to setup traefik router, and run `make qa`
 
 You will find details and a step-by-step guide for both scenario in [INSTALL.md](./docs/INSTALL.md)
 
@@ -91,7 +91,6 @@ More detailed can be found in [HELPERS.md](./docs/HELPERS.md)
 
 ### Look for what's coming next...
 
-1. Make use of MariaDB and Nginx
 1. Add a `make migration` to change URI easily (and update paths)
 1. Consolidate for production (a bit of monitoring, backup)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ More detailed can be found in [HELPERS.md](./docs/HELPERS.md)
 ### Look for what's coming next...
 
 1. Make use of MariaDB and Nginx
-1. Consolidate for production
+1. Add a `make migration` to change URI easily (and update paths)
+1. Consolidate for production (a bit of monitoring, backup)
 
 ### Something is missing ?
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ More detailed can be found in [HELPERS.md](./docs/HELPERS.md)
 
 ### Look for what's coming next...
 
+1. Configure NGinx for images
+    - https://www.ghostforbeginners.com/smaller-images/
+    - https://attilathedud.me/photo-gallery-on-ghost-blog/
+    1. Add (selenium) tests
 1. Add a `make migration` to change URI easily (and update paths)
 1. Consolidate for production (a bit of monitoring, backup)
 
@@ -105,7 +109,8 @@ All notable changes to this project are documented in [CHANGELOG.md](./CHANGELOG
 
 ### :warning: Backward incompatible changes
 
-- v0.2.0 : data volumes are now created within subfolder ./instances. You will need to move your data from the root folder into this new place
+- :boom: v0.2.0 : data volumes are now created within subfolder ./instances. You will need to move your data from the root folder into this new place
+- :alarm_clock: v0.4.0: `make traefik` replaced with `make qa` instead
 
 ## Contribution
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,13 +39,13 @@ Feel free to use my companion repo, [prod-stack](https://github.com/ebreton/prod
 
 Variables are defined in [.env](../.env) file, and can be modified in the command line when calling `make`. The file is self-documented, but here is a summary of the variables and default values:
 
-Name | description | default | used by standalone container / traefik
+Name | description | default | deployment where used
 ---------|----------|----------|---------
- NAME | for the container and the data folder (stored within _./instances_) | ghost-local | both
- PROTOCOL | to build the URL | http | traefik
- DOMAIN | to build the URL | localhost | both
- PORT | to build the URL | 3001 | standalone
- URI | to build the URL | ${NAME} | traefik
+ NAME | for the container and the data folder (stored within _./instances_) | ghost-local | dev, qa, prod
+ PROTOCOL | to build the URL | http | qa, prod (traefik)
+ DOMAIN | to build the URL | localhost | dev, qa, prod
+ PORT | to build the URL | 3001 | dev
+ URI | to build the URL | ${NAME} | qa, prod (traefik)
 
 ### Run on a per-port basis
 
@@ -86,9 +86,9 @@ You will be able to check that everything went ok
 
 The [prod-stack](https://github.com/ebreton/prod-stack) will actually offer you more than a proxy-combo: you will get what you could need in production (Nginx, MariaDB, and use of Let's Encrypt for HTTPs)
 
-Once you have started your stack as indicated on [prod-stack](https://github.com/ebreton/prod-stack), you will just need to run `make traefik` and head to <http://localhost/ghost-local>
+Once you have started your stack as indicated on [prod-stack](https://github.com/ebreton/prod-stack), you will just need to run `make qa` and head to <http://localhost/ghost-local>
 
-    $ make traefik
+    $ make qa
     # Start a ghost container behind traefik (therefore available through 80 or 443), on path $NAME
     # Beware of --network used, which is the same one traefik should be using
     docker run --rm -d --name ghost-local \
@@ -104,8 +104,8 @@ Once you have started your stack as indicated on [prod-stack](https://github.com
 
 If you have already launched a container with the default environment variables, you will need to define another NAME:
 
-* `NAME=hello make traefik` to get a fresh blog running on <http://localhost/hello>
-* `NAME=bye make traefik` to get another blog running on <http://localhost/bye>
+* `NAME=hello make qa` to get a fresh blog running on <http://localhost/hello>
+* `NAME=bye make qa` to get another blog running on <http://localhost/bye>
 * and so on...
 
 ### HTTPs ?

--- a/prod.env.sample
+++ b/prod.env.sample
@@ -1,0 +1,8 @@
+# password set for db-shared, as defined in prod-stack/etc/db.env
+MYSQL_ROOT_PASSWORD=mysql_root_password
+
+# see https://docs.ghost.org/docs/mail-config#section-mailgun
+# wou will find an updated screencast to understand exactly where to find these details
+MAILGUN_LOGIN=Sandbox default SMTP Login
+MAILGUN_PASSWORD=Sandbox default Password
+


### PR DESCRIPTION
**Targetted version**: 0.2.1

**High level changes:**

1. ⚠️  Renamed `make traefik` to `make qa`
1. Added `make prod`, which makes use of
    * MySQL configuration for MariaDB (from [prod-stack](https://github.com/ebreton/prod-stack))
    * email configuration for Mailgun (as indicated in [official doc](https://docs.ghost.org/docs/mail-config#section-mailgun))
1. Added file *prod.env.sample* to create *prod.env* from
    * this file is **required** by `make prod`
1. Added `make restart-prod` and `make upgrade-prod`

**Low level changes:**

1. `make prod` runs Ghost with some container env variables,  database__* and email__* which make use respectively of host env variables:
    * `MYSQL_ROOT_PASSWORD`
    * `MAILGUN_LOGIN` and `MAILGUN_PASSWORD`
