### PR TITLE
Support multiple versions of Ghost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ gatling:
 
 cli-version:
 	docker exec -it ${NAME} ghost -v
+	@echo Latest version on Docker Hub: $(shell python find_latest_versions.py)
 
 ps:
 	# A lightly formatted version of docker ps

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 
 [dev-packages]
 requests = "*"
+pylint = "*"
+"flake8" = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9d9f51668c44d5a80df3d222d15a8450a7abff0d48d22df39754ba1c405d4b92"
+            "sha256": "7cb6ad1197d2b21ba4e2f66b523a21b67fce3f901fd9a3612363b41fd87ed32d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -17,6 +17,13 @@
     },
     "default": {},
     "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:032f6e09161e96f417ea7fad46d3fac7a9019c775f202182c22df0e4f714cb1c",
+                "sha256:dea42ae6e0b789b543f728ddae7ddb6740ba33a49fb52c4a4d9cb7bb4aa6ec09"
+            ],
+            "version": "==1.6.4"
+        },
         "certifi": {
             "hashes": [
                 "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
@@ -31,12 +38,91 @@
             ],
             "version": "==3.0.4"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
+                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
+            ],
+            "index": "pypi",
+            "version": "==3.5.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
                 "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
             ],
             "version": "==2.6"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+            ],
+            "version": "==4.3.4"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
+            ],
+            "version": "==2.3.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f",
+                "sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805"
+            ],
+            "version": "==1.6.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:aa519865f8890a5905fa34924fed0f3bfc7d84fc9f9142c16dac52ffecd25a39",
+                "sha256:c353d8225195b37cc3aef18248b8f3fe94c5a6a95affaf885ae21a24ca31d8eb"
+            ],
+            "index": "pypi",
+            "version": "==1.9.1"
         },
         "requests": {
             "hashes": [
@@ -46,12 +132,25 @@
             "index": "pypi",
             "version": "==2.18.4"
         },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
                 "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
             ],
             "version": "==1.22"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
+            ],
+            "version": "==1.10.11"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ ToC
 - [Helpers for developers](#helpers-for-developers)
 - [:construction: Production readyness](#construction--production-readyness)
 - [Interested ?](#interested)
-    - [Look for what's coming next...](#look-for-whats-coming-next)
-    - [Something is missing ?](#something-is-missing)
+  - [Look for what's coming next...](#look-for-whats-coming-next)
+  - [Something is missing ?](#something-is-missing)
 - [Changelog](#changelog)
 - [:warning: Backward incompatible changes](#warning--backward-incompatible-changes)
 - [Contribution](#contribution)
@@ -55,10 +55,11 @@ You want to play a bit more, and you would like to have multiple Ghosts on your 
 * or leverage the power of [traefik](https://traefik.io) and have multiple ghosts on a **per-path basis** (see section below)
     > e.g.: `NAME=yet-another make qa`. Head to <http://localhost/yet-another>
 
+By the way, you would like to run an old version of Ghost ? `GHOST_VERSION=x.x.x make qa` will do this for you. You can use whatever version is available on [docker hub](https://hub.docker.com/_/ghost)
+
 If you are worried with your data, be at rest: a local folder is created within path _./instances_, for every blog you create, named from $NAME variable. Stopping and restarting a blog with the same name will keep using the local data.
 
 ## Installation and usage
-
 
 Command | Description | Remarks
 ---------|----------|---------
@@ -83,7 +84,7 @@ Command | Description | Variables
 ---------|----------|---------
  `make vars` | Display the values of all env vars | All
  `make ps` | Display the running containers | None
- `make cli-version` | Display Ghost & ghost-cli version | NAME
+ `make cli-version` | Display Ghost & ghost-cli version, + latest version available on docker hub | NAME
  `make shell` | Connect to given Ghost container | NAME
  `make logs` | Tail and follow the logs of given Ghost container | NAME
  `make stop` | Stop given Ghost container | NAME
@@ -117,7 +118,6 @@ Command | Description
 1. Write make migrate
 1. Write make try-upgrade
 1. Write make list to get all created instances
-1. Add latest Ghost/-cli version in make cli-version
 1. Configure NGinx for cache
 
 ### Something is missing ?

--- a/docs/HELPERS.md
+++ b/docs/HELPERS.md
@@ -6,14 +6,16 @@ ToC
 
 <!-- TOC -->
 
-- [make vars](#make-vars)
-- [make ps](#make-ps)
-- [[NAME=ghost-local] make cli-version](#nameghost-local-make-cli-version)
-- [[NAME=ghost-local] make shell](#nameghost-local-make-shell)
-- [[NAME=ghost-local] make logs](#nameghost-local-make-logs)
-- [[NAME=ghost-local] make stop](#nameghost-local-make-stop)
-- [make pull](#make-pull)
-- [[NAME=ghost-local] make restart and make upgrades](#nameghost-local-make-restart-and-make-upgrades)
+- [Helpers for developers](#helpers-for-developers)
+    - [ToC](#toc)
+    - [make vars](#make-vars)
+    - [make ps](#make-ps)
+    - [[NAME=ghost-local] make cli-version](#nameghost-local-make-cli-version)
+    - [[NAME=ghost-local] make shell](#nameghost-local-make-shell)
+    - [[NAME=ghost-local] make logs](#nameghost-local-make-logs)
+    - [[NAME=ghost-local] make stop](#nameghost-local-make-stop)
+    - [make pull](#make-pull)
+    - [[NAME=ghost-local] make restart and make upgrades](#nameghost-local-make-restart-and-make-upgrades)
 
 <!-- /TOC -->
 
@@ -60,12 +62,13 @@ It will act as `docker ps`, displaying less columns
 
 ## [NAME=ghost-local] make cli-version
 
-Handy command to get Ghost and ghost-cli versions
+Handy command to get Ghost and ghost-cli versions, plus the latest ghost version available on the Docker Hub. You will need python (2 or 3) installed to run this command, with the module requests (`pip install requests` or running your commands from a `pipenv shell`)
 
     $ make cli-version
     docker exec -it ghost-local ghost -v
     Ghost-CLI version: 1.7.3
     Ghost Version (at /var/lib/ghost): 1.23.0
+    Latest version on Docker Hub: 1.23.0
 
 ## [NAME=ghost-local] make shell
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,14 +7,16 @@ ToC
 
 <!-- TOC -->
 
-- [Pre-requisites](#pre-requisites)
-    - [To run on a per-port basis](#to-run-on-a-per-port-basis)
-    - [To run on a per-path basis](#to-run-on-a-per-path-basis)
-- [Setup](#setup)
-    - [Default configuration](#default-configuration)
-    - [Run on a per-port basis](#run-on-a-per-port-basis)
-    - [Run on a per-path basis](#run-on-a-per-path-basis)
-    - [HTTPs ?](#https-)
+- [](#markdownlint-disable-md034)
+    - [ToC](#toc)
+    - [Pre-requisites](#pre-requisites)
+        - [To run on a per-port basis](#to-run-on-a-per-port-basis)
+        - [To run on a per-path basis](#to-run-on-a-per-path-basis)
+    - [Setup](#setup)
+        - [Default configuration](#default-configuration)
+        - [Run on a per-port basis](#run-on-a-per-port-basis)
+        - [Run on a per-path basis](#run-on-a-per-path-basis)
+        - [HTTPs ?](#https)
 
 <!-- /TOC -->
 
@@ -24,6 +26,7 @@ ToC
 
 * [make](https://www.gnu.org/software/make/)
 * [docker](https://www.docker.com/community-edition)
+* python (2 or 3) with requests library (`pip install requests` or running your commands from a `pipenv shell`) if you want to have a few extended features, like `make cli-version` returning the latest ghost version available on docker hub.
 
 That's it!
 
@@ -46,10 +49,11 @@ Name | description | default | deployment where used
  DOMAIN | to build the URL | localhost | dev, qa, prod
  PORT | to build the URL | 3001 | dev
  URI | to build the URL | ${NAME} | qa, prod (traefik)
+ GHOST_VERSION | which docker image to use | 1 | dev, qa, prod. '-alpine' is added after the version number
 
 ### Run on a per-port basis
 
-> The following variables will be used: NAME, DOMAIN, PORT, URI
+> The following variables will be used: NAME, DOMAIN, PORT, URI, GHOST_VERSION
 
 To get everything running, what could be better than one line?
 
@@ -80,9 +84,13 @@ You will be able to check that everything went ok
 
     NAME=another PORT=3002 make
 
+> Another version ?
+
+    GHOST_VERSION=1.11 NAME=old-buddy PORT=3003 make
+
 ### Run on a per-path basis
 
-> The following variables will be used: NAME, PROTOCOL, DOMAIN, URI
+> The following variables will be used: NAME, PROTOCOL, DOMAIN, URI, GHOST_VERSION
 
 The [prod-stack](https://github.com/ebreton/prod-stack) will actually offer you more than a proxy-combo: you will get what you could need in production (Nginx, MariaDB, and use of Let's Encrypt for HTTPs)
 
@@ -105,7 +113,7 @@ Once you have started your stack as indicated on [prod-stack](https://github.com
 If you have already launched a container with the default environment variables, you will need to define another NAME:
 
 * `NAME=hello make qa` to get a fresh blog running on <http://localhost/hello>
-* `NAME=bye make qa` to get another blog running on <http://localhost/bye>
+* `GHOST_VERSION=0.10 NAME=bye make qa` to get another (old) blog running on <http://localhost/bye>
 * and so on...
 
 ### HTTPs ?

--- a/etc/prod.env.sample
+++ b/etc/prod.env.sample
@@ -2,7 +2,7 @@
 MYSQL_ROOT_PASSWORD=mysql_root_password
 
 # see https://docs.ghost.org/docs/mail-config#section-mailgun
-# wou will find an updated screencast to understand exactly where to find these details
+# you will find an updated screencast to understand exactly where to find these details
 MAILGUN_LOGIN=Sandbox default SMTP Login
 MAILGUN_PASSWORD=Sandbox default Password
 

--- a/find_latest_versions.py
+++ b/find_latest_versions.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+
+from distutils.version import LooseVersion
+
+import argparse
+import logging
+import requests
+import re
+
+from update_release import  set_logging_config
+from versions import _version
+
+session = requests.Session()
+
+# authorization token
+TOKEN_URL = "https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull"
+
+# find all tags
+TAGS_URL =  "https://index.docker.io/v2/%s/tags/list"
+TAG_RE = re.compile("^[\d]+(\.[\d]+)*$")
+
+# get image digest for target
+TARGET_DIGEST = "https://index.docker.io/v2/%(repository)s/manifests/%(tag)s"
+
+class Fetcher:
+
+    DIGEST_HEADER = {}
+
+    def __init__(self, repository):
+        self.repository = repository
+        self.token = self.get_token()
+        self.headers = {"Authorization": "Bearer %s"% self.token}
+        self.headers_for_tags = {
+            "Authorization": "Bearer %s"% self.token,
+            "Accept": "application/vnd.docker.distribution.manifest.v2+json"
+        }
+        logging.debug("initialized fetcher for %s", self.repository)
+
+
+    def get_token(self):
+        response = session.get(TOKEN_URL % self.repository)
+        response.raise_for_status()
+        token = response.json().get("token")
+        logging.debug("got token: %s", token)
+        return token
+
+
+    def get_versions(self):
+        response = session.get(TAGS_URL % self.repository, headers=self.headers_for_tags)
+        response.raise_for_status()
+        all_tags = response.json().get("tags")
+        numbered_tags = filter(lambda x: TAG_RE.match(x), all_tags)
+        versions = map(LooseVersion, numbered_tags)
+        logging.debug("got tags: %s", versions)
+        return versions
+
+
+def find_latest(repository):
+    fetcher = Fetcher(repository)
+    all_tags = fetcher.get_versions()
+    return max(all_tags)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        usage="""Version checker script
+
+This file retreives the latest version of ghost container image from docker hub
+It can be run with both python 2.7 and 3.6""")
+    parser.add_argument("repository", nargs='?', 
+        help="repository name [default:library/ghost]",
+        default="library/ghost")
+    parser.add_argument('-v', '--version', action='store_true')
+    parser.add_argument('-d', '--debug', action='store_true')
+    parser.add_argument('-q', '--quiet', action='store_true')
+    args = parser.parse_args()
+
+    set_logging_config(quiet=args.quiet, debug=args.debug)
+    logging.debug(args)
+
+    # version needs to be print to output in order to be retrieved by Makefile
+    if args.version:
+        print(_version)
+        raise SystemExit()
+
+    print(find_latest(args.repository))

--- a/versions.py
+++ b/versions.py
@@ -3,14 +3,14 @@
 
 # the release comes from git and should not be modified
 # => read-only
-_release = '0.2.0-19-g9f30542'
+_release = '0.2.1-8-g6eb58a2'
 
 # you can set the next version number manually
 # if you do not, the system will make sure that version > release
 # => read-write, >_release
-_version = '0.2.1'
+_version = '0.2.2'
 
 # the build number will generate conflicts on each PR merge
 # just keep yours every time
 # => read-only
-_build = '9f3054288dea1f3afba99c9c7c45da615c22c78f'
+_build = '6eb58a2bc599562f1ce0739d33117cb0703edcc5'


### PR DESCRIPTION
**Targetted version**: 0.2.2

**High level changes:**

1. Added env var GHOST_VERSION to spawn any version of Ghost
1. Added latest version of ghost available on docker hub in command `make cli-version`

**Low level changes:**

1. python required to run `make cli-version`, with the lib `requests`
